### PR TITLE
Add resources requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ In the future we intend to support the following additional usages :
 
 ## Compatibility
 
-| Feature         | Status      | Comment |
-| --------------- | ----------- | ------- |
-| Single app      | Ok          |         |
-| Group           | In progress |         |
-| Instances       | Ok          |         |
-| CPU / Mem       | In progress |         |
-| PORT_MAPPINGS   | Ok          |         |
-| Env             | Ok          |         |
-| HAPROXY_X_VHOST | Ok          |         |
-| Fetch           | In progress |         |
-| Healthcheck     |             |         |
+| Feature         | Status      | Comment                                                  |
+| --------------- | ----------- | -------------------------------------------------------- |
+| Single app      | Ok          |                                                          |
+| Group           | In progress |                                                          |
+| Instances       | Ok          |                                                          |
+| CPU / Mem       | Ok          | Resources are defined as "resources requests" not limits |
+| PORT_MAPPINGS   | Ok          |                                                          |
+| Env             | Ok          |                                                          |
+| HAPROXY_X_VHOST | Ok          |                                                          |
+| Fetch           | In progress |                                                          |
+| Healthcheck     |             |                                                          |

--- a/core/src/main/java/fr/insee/innovation/marathontokubernetes/core/services/converter/MarathonToKubernetesConverter.java
+++ b/core/src/main/java/fr/insee/innovation/marathontokubernetes/core/services/converter/MarathonToKubernetesConverter.java
@@ -18,6 +18,9 @@ import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.QuantityBuilder;
+import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
 import io.fabric8.kubernetes.api.model.ServicePort;
 import io.fabric8.kubernetes.api.model.ServicePortBuilder;
@@ -95,6 +98,10 @@ public class MarathonToKubernetesConverter {
         if (appToConvert.getContainer().getDocker().isPrivileged()) {
             containerBuilder.editOrNewSecurityContext().withPrivileged(true).endSecurityContext();
         }
+        Map<String,Quantity> resourcesRequests = new HashMap<>();
+        resourcesRequests.put("memory",new QuantityBuilder().withNewAmount(appToConvert.getMem().intValue()+"M").build());
+        resourcesRequests.put("cpu",new QuantityBuilder().withNewAmount((appToConvert.getCpus()*1000)+"m").build());
+        containerBuilder.withResources(new ResourceRequirementsBuilder().withRequests(resourcesRequests).build());
         Container container = containerBuilder.withName(name).withImage(appToConvert.getContainer().getDocker().getImage()).build();
 
         return new DeploymentBuilder()


### PR DESCRIPTION
Add support for resources requests.  
We may want to implement resources limits one day but at the moment, we find that resources requests are more suited for our usage.  
See https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/ for documentation about kubernetes resources requirements